### PR TITLE
Update dead URL for nimtorch

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@
 ## Deep Learning
 
 - [Arraymancer](https://github.com/mratsim/Arraymancer) - A fast, ergonomic and portable tensor library in Nim with a deep learning focus for CPU, GPU, OpenCL and embedded devices.
-- [NimTorch](https://gitlab.fragcolor.xyz/fragcolor/nimtorch) - PyTorch - Python + Nim. A Nim front-end to PyTorch's native backend, combining Nim's speed, productivity and portability with PyTorch's latest implementations.
+- [NimTorch](https://github.com/sinkingsugar/nimtorch) - PyTorch - Python + Nim. A Nim front-end to PyTorch's native backend, combining Nim's speed, productivity and portability with PyTorch's latest implementations.
 
 
 ## Design


### PR DESCRIPTION
- previous [link](https://gitlab.fragcolor.xyz/fragcolor/nimtorch) was dead
- changed link to https://github.com/sinkingsugar/nimtorch